### PR TITLE
Enable dynamic tool config schema

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,4 +1,5 @@
 import { Command } from '@oclif/core';
+
 import { loadDcoreConfig } from '../config/load-config.js';
 import { ProjectGenerator } from '../projects/project-generator.js';
 

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { z } from 'zod';
 
-const toolSetting = z.union([z.boolean(), z.record(z.string(), z.any())]);
+import { buildToolSchema } from '../generators/tool-registry.js';
 
 export const dcoreConfigSchema = z.object({
   ci: z.enum(['github', 'gitlab']).optional(),
@@ -22,12 +22,7 @@ export const dcoreConfigSchema = z.object({
   projectType: z.enum(['cdk-app', 'cdk-lib', 'ts-lib']),
   projectVersion: z.string().optional(),
   release: z.enum(['changesets', 'semantic-release']).optional(),
-  tools: z.object({
-    eslint: toolSetting.optional(),
-    jest: toolSetting.optional(),
-    prettier: toolSetting.optional(),
-    typedoc: toolSetting.optional(),
-  }),
+  tools: buildToolSchema(),
 });
 
 export type DcoreConfig = z.infer<typeof dcoreConfigSchema>;

--- a/src/generators/eslint/eslint-generator.ts
+++ b/src/generators/eslint/eslint-generator.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
+
 import { PackageJsonGenerator } from '../package-json/package-json-generator.js';
 import {
+  DEFAULT_IGNORE_ENTRIES,
   GeneratorConfig,
   ToolGenerator,
-  DEFAULT_IGNORE_ENTRIES,
 } from '../tool-generator.js';
 
 export class EslintGenerator extends ToolGenerator {
@@ -24,26 +25,6 @@ export class EslintGenerator extends ToolGenerator {
         rules: z.record(z.string(), z.any()).optional(),
       }),
     ]);
-  }
-
-  override shouldRun(config: GeneratorConfig): boolean {
-    return Boolean(this.getToolConfig(config));
-  }
-
-  protected override getDefaultConfig(): Record<string, unknown> {
-    return {
-      root: true,
-      env: {
-        node: true,
-        es2020: true,
-      },
-      extends: ['eslint:recommended'],
-      parserOptions: {
-        ecmaVersion: 'latest',
-        sourceType: 'module',
-      },
-      rules: {},
-    };
   }
 
   async generate(config: GeneratorConfig): Promise<void> {
@@ -90,5 +71,25 @@ export default ${JSON.stringify(merged, null, 2)};`;
     await this.appendToIgnoreFile('.eslintignore', ...DEFAULT_IGNORE_ENTRIES);
 
     this.pkg?.addDevDependency('eslint', '^8.56.0');
+  }
+
+  protected override getDefaultConfig(): Record<string, unknown> {
+    return {
+      env: {
+        es2020: true,
+        node: true,
+      },
+      extends: ['eslint:recommended'],
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+      root: true,
+      rules: {},
+    };
+  }
+
+  override shouldRun(config: GeneratorConfig): boolean {
+    return Boolean(this.getToolConfig(config));
   }
 }

--- a/src/generators/package-json/get-fields.ts
+++ b/src/generators/package-json/get-fields.ts
@@ -1,16 +1,18 @@
-export function getBaseFields(config: any): Record<string, unknown> {
+import type { GeneratorConfig } from '../tool-generator.js';
+
+export function getBaseFields(config: Partial<GeneratorConfig>): Record<string, unknown> {
   return {
-    name: config.projectName || 'my-project',
-    version: config.projectVersion || '0.1.0',
-    description: config.projectDesription || '',
     author: config.projectAuthor || '',
+    description: config.projectDesription || '',
     license: config.projectLicense || 'MIT',
+    name: config.projectName || 'my-project',
     private: true,
     type: 'module',
+    version: config.projectVersion || '0.1.0',
   };
 }
 
-export function getScripts(config: any): Record<string, string> {
+export function getScripts(config: Partial<GeneratorConfig>): Record<string, string> {
   const scripts: Record<string, string> = {
     build: 'tsc',
     format: 'prettier --check .',
@@ -32,8 +34,8 @@ export function getScripts(config: any): Record<string, string> {
   return scripts;
 }
 
-export function getExportFields(config: any): Record<string, unknown> {
-  const { main, types, exports: exp, files } = config.exports || {};
+export function getExportFields(config: Partial<GeneratorConfig>): Record<string, unknown> {
+  const { exports: exp, files, main, types } = config.exports || {};
 
   const anyDefined = main || types || exp || files;
   const allDefined = main && types && exp && files;
@@ -46,18 +48,16 @@ export function getExportFields(config: any): Record<string, unknown> {
 
   if (allDefined) {
     return {
-      main,
-      types,
       exports: exp,
       files,
+      main,
+      types,
     };
   }
 
   // Defaults, if nothing provided
   if (config.projectType === 'ts-lib' || config.projectType === 'cdk-lib') {
     return {
-      main: './dist/index.js',
-      types: './dist/index.d.ts',
       exports: {
         '.': {
           import: './dist/index.js',
@@ -65,6 +65,8 @@ export function getExportFields(config: any): Record<string, unknown> {
         },
       },
       files: ['dist'],
+      main: './dist/index.js',
+      types: './dist/index.d.ts',
     };
   }
 

--- a/src/generators/package-json/package-json-generator.ts
+++ b/src/generators/package-json/package-json-generator.ts
@@ -3,8 +3,7 @@ import { getBaseFields, getExportFields, getScripts } from './get-fields.js';
 
 export class PackageJsonGenerator extends ToolGenerator {
   name = 'package.json';
-
-  private dependencies = new Map<string, string>();
+private dependencies = new Map<string, string>();
   private devDependencies = new Map<string, string>();
   private optionalDependencies = new Map<string, string>();
   private peerDependencies = new Map<string, string>();
@@ -23,29 +22,6 @@ export class PackageJsonGenerator extends ToolGenerator {
 
   addPeerDependency(pkg: string, version: string): void {
     this.peerDependencies.set(pkg, version);
-  }
-
-  shouldRun(): boolean {
-    return true;
-  }
-
-  protected getDefaultDevDeps(): Record<string, string> {
-    return {
-      eslint: '^8.56.0',
-      prettier: '^3.2.5',
-      typescript: '^5.3.3',
-    };
-  }
-
-  private mergeDeps(
-    base: Record<string, string> = {},
-    extras: Map<string, string>
-  ): Record<string, string> {
-    const result = { ...base };
-    for (const [name, version] of extras) {
-      result[name] = version;
-    }
-    return result;
   }
 
   async generate(config: GeneratorConfig): Promise<void> {
@@ -68,7 +44,7 @@ export class PackageJsonGenerator extends ToolGenerator {
       devDependencies: this.mergeDeps(
         {
           ...this.getDefaultDevDeps(),
-          ...(extraDeps.devDependencies ?? {}),
+          ...extraDeps.devDependencies,
         },
         this.devDependencies
       ),
@@ -89,5 +65,27 @@ export class PackageJsonGenerator extends ToolGenerator {
     }
 
     await this.writeJsonFile('package.json', pkg);
+  }
+
+  protected getDefaultDevDeps(): Record<string, string> {
+    return {
+      typescript: '^5.3.3',
+    };
+  }
+
+  shouldRun(): boolean {
+    return true;
+  }
+
+  private mergeDeps(
+    base: Record<string, string> = {},
+    extras: Map<string, string>
+  ): Record<string, string> {
+    const result = { ...base };
+    for (const [name, version] of extras) {
+      result[name] = version;
+    }
+
+    return result;
   }
 }

--- a/src/generators/prettier/prettier-generator.ts
+++ b/src/generators/prettier/prettier-generator.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import { PackageJsonGenerator } from '../package-json/package-json-generator.js';
 import {
   DEFAULT_IGNORE_ENTRIES,
@@ -32,8 +33,16 @@ export class PrettierGenerator extends ToolGenerator {
     ]);
   }
 
-  shouldRun(config: GeneratorConfig): boolean {
-    return Boolean(config.tools?.prettier);
+  async generate(config: GeneratorConfig): Promise<void> {
+    const raw = config.tools?.prettier;
+    const prettierCfg = ToolGenerator.isRecord(raw)
+      ? this.getMergedConfig(raw)
+      : this.getMergedConfig({});
+
+    await this.writeJsonFile('.prettierrc', prettierCfg);
+    await this.appendToIgnoreFile('.prettierignore', ...DEFAULT_IGNORE_ENTRIES);
+
+    this.pkg?.addDevDependency('prettier', '^3.2.5');
   }
 
   protected override getDefaultConfig(): Record<string, unknown> {
@@ -49,15 +58,7 @@ export class PrettierGenerator extends ToolGenerator {
     };
   }
 
-  async generate(config: GeneratorConfig): Promise<void> {
-    const raw = config.tools?.prettier;
-    const prettierCfg = ToolGenerator.isRecord(raw)
-      ? this.getMergedConfig(raw)
-      : this.getMergedConfig({});
-
-    await this.writeJsonFile('.prettierrc', prettierCfg);
-    await this.appendToIgnoreFile('.prettierignore', ...DEFAULT_IGNORE_ENTRIES);
-
-    this.pkg?.addDevDependency('prettier', '^3.2.5');
+  shouldRun(config: GeneratorConfig): boolean {
+    return Boolean(config.tools?.prettier);
   }
 }

--- a/src/generators/tool-registry.ts
+++ b/src/generators/tool-registry.ts
@@ -1,7 +1,8 @@
 import { z } from 'zod';
+
 import { EslintGenerator } from './eslint/eslint-generator';
-import { PrettierGenerator } from './prettier/prettier-generator';
 import { PackageJsonGenerator } from './package-json/package-json-generator';
+import { PrettierGenerator } from './prettier/prettier-generator';
 import { TsConfigGenerator } from './tsconfig/tsconfig-generator';
 
 export const toolGenerators = [
@@ -11,10 +12,10 @@ export const toolGenerators = [
   TsConfigGenerator,
 ];
 
-export function buildToolSchema(): z.ZodObject<any> {
+export function buildToolSchema(): z.AnyZodObject {
   const entries = toolGenerators
-    .filter((g) => !!g.configSchema)
-    .map((g) => [g.prototype.name, g.configSchema!]);
+    .filter((g) => Boolean(g.configSchema))
+    .map((g) => [g.prototype.name, g.configSchema!.optional()]);
 
   return z.object(Object.fromEntries(entries));
 }

--- a/src/projects/project-generator.ts
+++ b/src/projects/project-generator.ts
@@ -1,8 +1,8 @@
-import { EslintGenerator } from '../generators/eslint-generator';
-import { PackageJsonGenerator } from '../generators/package-json-generator';
-import { PrettierGenerator } from '../generators/prettier-generator';
-import { GeneratorConfig, ToolGenerator } from '../generators/tool-generator';
-import { TsConfigGenerator } from '../generators/tsconfig-generator';
+import { EslintGenerator } from '../generators/eslint/eslint-generator.js';
+import { PackageJsonGenerator } from '../generators/package-json/package-json-generator.js';
+import { PrettierGenerator } from '../generators/prettier/prettier-generator.js';
+import { GeneratorConfig, ToolGenerator } from '../generators/tool-generator.js';
+import { TsConfigGenerator } from '../generators/tsconfig/tsconfig-generator.js';
 
 export class ProjectGenerator {
   private readonly generators: ToolGenerator[];

--- a/test/generators/eslint-generator.test.ts
+++ b/test/generators/eslint-generator.test.ts
@@ -3,8 +3,8 @@ import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { EslintGenerator } from '../../src/generators/eslint-generator.js';
-import { PackageJsonGenerator } from '../../src/generators/package-json-generator.js';
+import { EslintGenerator } from '../../src/generators/eslint/eslint-generator.js';
+import { PackageJsonGenerator } from '../../src/generators/package-json/package-json-generator.js';
 
 describe('EslintGenerator', () => {
   it('generates config and registers dependency', async () => {
@@ -12,7 +12,7 @@ describe('EslintGenerator', () => {
     const pkg = new PackageJsonGenerator(dir);
     const gen = new EslintGenerator(dir, pkg);
 
-    await gen.generate({ tools: { eslint: true } });
+    await gen.generate({ projectName: 'demo', projectType: 'ts-lib', tools: { eslint: true } });
     await pkg.generate({ projectName: 'demo', projectType: 'ts-lib', tools: {} });
 
     const rcPath = join(dir, '.eslintrc.cjs');

--- a/test/generators/package-json-generator.test.ts
+++ b/test/generators/package-json-generator.test.ts
@@ -3,7 +3,8 @@ import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { PackageJsonGenerator } from '../../src/generators/package-json-generator.js';
+import { PackageJsonGenerator } from '../../src/generators/package-json/package-json-generator.js';
+import { GeneratorConfig } from '../../src/generators/tool-generator.js';
 
 describe('PackageJsonGenerator', () => {
   it('writes package.json with merged dependencies', async () => {
@@ -14,7 +15,7 @@ describe('PackageJsonGenerator', () => {
     pkg.addPeerDependency('baz', '^3.0.0');
     pkg.addOptionalDependency('qux', '^4.0.0');
 
-    const config = {
+    const config: GeneratorConfig = {
       dependencies: {
         dependencies: { express: '^5.0.0' },
         devDependencies: { eslint: '^8.0.0' },

--- a/test/generators/prettier-generator.test.ts
+++ b/test/generators/prettier-generator.test.ts
@@ -3,8 +3,8 @@ import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { PackageJsonGenerator } from '../../src/generators/package-json-generator.js';
-import { PrettierGenerator } from '../../src/generators/prettier-generator.js';
+import { PackageJsonGenerator } from '../../src/generators/package-json/package-json-generator.js';
+import { PrettierGenerator } from '../../src/generators/prettier/prettier-generator.js';
 
 describe('PrettierGenerator', () => {
   it('creates files and registers dependency', async () => {
@@ -12,7 +12,7 @@ describe('PrettierGenerator', () => {
     const pkg = new PackageJsonGenerator(dir);
     const gen = new PrettierGenerator(dir, pkg);
 
-    await gen.generate({ tools: { prettier: true } });
+    await gen.generate({ projectName: 'demo', projectType: 'ts-lib', tools: { prettier: true } });
     await pkg.generate({ projectName: 'demo', projectType: 'ts-lib', tools: {} });
 
     const rcPath = join(dir, '.prettierrc');

--- a/test/generators/tsconfig-generator.test.ts
+++ b/test/generators/tsconfig-generator.test.ts
@@ -3,8 +3,8 @@ import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { PackageJsonGenerator } from '../../src/generators/package-json-generator.js';
-import { TsConfigGenerator } from '../../src/generators/tsconfig-generator.js';
+import { PackageJsonGenerator } from '../../src/generators/package-json/package-json-generator.js';
+import { TsConfigGenerator } from '../../src/generators/tsconfig/tsconfig-generator.js';
 
 describe('TsConfigGenerator', () => {
   it('creates tsconfig and registers dependency', async () => {


### PR DESCRIPTION
## Summary
- make tool configuration schema dynamic
- add getToolConfig helper in base generator class
- keep project imports updated
- update tests for stricter GeneratorConfig
- allow tsconfig overrides and drop default eslint/prettier deps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e99b366c08321a03389e6862b05cc