### PR TITLE
Add git init on project creation only

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@oclif/core": "^4",
     "@oclif/plugin-help": "^6",
     "@oclif/plugin-plugins": "^5",
+    "simple-git": "3.28.0",
     "zod": "^3.25.64"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@oclif/plugin-plugins':
         specifier: ^5
         version: 5.4.40
+      simple-git:
+        specifier: 3.28.0
+        version: 3.28.0
       zod:
         specifier: ^3.25.64
         version: 3.25.64
@@ -502,6 +505,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@kwsites/promise-deferred@1.1.1':
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
@@ -2632,6 +2641,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-git@3.28.0:
+    resolution: {integrity: sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==}
+
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
@@ -3764,6 +3776,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.1(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@kwsites/promise-deferred@1.1.1': {}
 
   '@napi-rs/wasm-runtime@0.2.11':
     dependencies:
@@ -6217,6 +6237,14 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   signal-exit@4.1.0: {}
+
+  simple-git@3.28.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      debug: 4.4.1(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
 
   snake-case@3.0.4:
     dependencies:

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -11,7 +11,7 @@ export default class Dcore extends Command {
     const config = await loadDcoreConfig();
     this.log('✅ Configuration loaded.');
 
-    const generator = new ProjectGenerator(config);
+    const generator = new ProjectGenerator({ ...config, isInit: false });
     await generator.generateAll();
 
     this.log('🎉 Project updated successfully!');

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -43,7 +43,7 @@ export default class Init extends Command {
     this.log('✅ Created .dcorerc.ts');
 
     const config = await loadDcoreConfig();
-    const generator = new ProjectGenerator(config);
+    const generator = new ProjectGenerator({ ...config, isInit: true });
     await generator.generateAll();
 
     this.log('🎉 Project initialized successfully!');

--- a/src/generators/git/git-generator.ts
+++ b/src/generators/git/git-generator.ts
@@ -1,0 +1,34 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { simpleGit } from 'simple-git';
+
+import { DEFAULT_IGNORE_ENTRIES, GeneratorConfig, ToolGenerator } from '../tool-generator.js';
+
+export class GitGenerator extends ToolGenerator {
+  name = 'git';
+
+  async generate(config: GeneratorConfig): Promise<void> {
+    const entries = [
+      ...DEFAULT_IGNORE_ENTRIES,
+      'tmp',
+      '*-debug.log',
+      '*-error.log',
+      '**/.DS_Store',
+      '.idea',
+    ];
+
+    await this.appendToIgnoreFile('.gitignore', ...entries);
+
+    if (config.isInit) {
+      const gitDir = resolve(this.projectRoot, '.git');
+      if (!existsSync(gitDir)) {
+        const git = simpleGit(this.projectRoot);
+        await git.init();
+      }
+    }
+  }
+
+  shouldRun(): boolean {
+    return true;
+  }
+}

--- a/src/generators/tool-generator.ts
+++ b/src/generators/tool-generator.ts
@@ -22,6 +22,8 @@ export interface GeneratorConfig extends DcoreConfig {
     main?: string;
     types?: string;
   };
+  /** Indicates that generation is triggered during `dcore init` */
+  isInit?: boolean;
   projectHomepage?: string;
   projectKeywords?: string[];
   projectRepository?: string;

--- a/src/generators/tool-registry.ts
+++ b/src/generators/tool-registry.ts
@@ -1,14 +1,16 @@
 import { z } from 'zod';
 
 import { EslintGenerator } from './eslint/eslint-generator';
+import { GitGenerator } from './git/git-generator';
 import { PackageJsonGenerator } from './package-json/package-json-generator';
 import { PrettierGenerator } from './prettier/prettier-generator';
 import { TsConfigGenerator } from './tsconfig/tsconfig-generator';
 
 export const toolGenerators = [
   EslintGenerator,
-  PrettierGenerator,
+  GitGenerator,
   PackageJsonGenerator,
+  PrettierGenerator,
   TsConfigGenerator,
 ];
 

--- a/src/projects/project-generator.ts
+++ b/src/projects/project-generator.ts
@@ -1,4 +1,5 @@
 import { EslintGenerator } from '../generators/eslint/eslint-generator.js';
+import { GitGenerator } from '../generators/git/git-generator.js';
 import { PackageJsonGenerator } from '../generators/package-json/package-json-generator.js';
 import { PrettierGenerator } from '../generators/prettier/prettier-generator.js';
 import { GeneratorConfig, ToolGenerator } from '../generators/tool-generator.js';
@@ -14,6 +15,7 @@ export class ProjectGenerator {
       new EslintGenerator(this.projectRoot, pkg),
       new TsConfigGenerator(this.projectRoot, pkg),
       new PrettierGenerator(this.projectRoot, pkg),
+      new GitGenerator(this.projectRoot),
     ];
   }
 

--- a/test/generators/git-generator.test.ts
+++ b/test/generators/git-generator.test.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { GitGenerator } from '../../src/generators/git/git-generator.js';
+
+describe('GitGenerator', () => {
+  it('creates .gitignore and initializes repo during init', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'dcore-git-'));
+    const gen = new GitGenerator(dir);
+
+    await gen.generate({ isInit: true, projectName: 'demo', projectType: 'ts-lib', tools: {} });
+
+    const ignorePath = join(dir, '.gitignore');
+    const gitDir = join(dir, '.git');
+
+    expect(await fs.readFile(ignorePath, 'utf8')).to.contain('node_modules');
+    expect((await fs.stat(gitDir)).isDirectory()).to.equal(true);
+  });
+
+  it('skips git init when not running init', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'dcore-git-'));
+    const gen = new GitGenerator(dir);
+
+    await gen.generate({ isInit: false, projectName: 'demo', projectType: 'ts-lib', tools: {} });
+
+    const gitDir = join(dir, '.git');
+    expect(await fs.stat(gitDir).catch(() => null)).to.equal(null);
+  });
+});


### PR DESCRIPTION
## Summary
- add `isInit` flag to generator config
- conditionally run `git init` only when `isInit` is true
- forward `isInit` from `init` and `dcore` commands
- extend tests for GitGenerator to check init behavior

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_685063a26fa483219dc74e8e7c85efa2