### PR TITLE
Add AWS CDK project generators

### DIFF
--- a/src/generators/cdk/cdk-app-generator.ts
+++ b/src/generators/cdk/cdk-app-generator.ts
@@ -1,0 +1,50 @@
+import { mkdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { pascalCase } from '../../utils/string.js';
+import { GeneratorConfig } from '../tool-generator.js';
+import { CdkCommon } from './cdk-common.js';
+
+export class CdkAppGenerator extends CdkCommon {
+  name = 'cdk-app';
+
+  async generate(config: GeneratorConfig): Promise<void> {
+    const name = config.projectName || 'cdk-app';
+    const pascal = pascalCase(name);
+
+    await this.writeJsonFile('cdk.json', {
+      app: `npx ts-node --prefer-ts-exts bin/${name}.ts`,
+    });
+
+    await mkdir(resolve(this.projectRoot, 'bin'), { recursive: true });
+    await mkdir(resolve(this.projectRoot, 'lib'), { recursive: true });
+
+    const binContent = `#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { ${pascal}Stack } from '../lib/${name}-stack.js';
+
+const app = new cdk.App();
+new ${pascal}Stack(app, '${pascal}Stack');
+`;
+    const stackContent = `import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+export class ${pascal}Stack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+  }
+}
+`;
+
+    await this.writeTextFile(`bin/${name}.ts`, binContent);
+    await this.writeTextFile(`lib/${name}-stack.ts`, stackContent);
+
+    this.addRuntimeDependencies();
+    this.addDevDependencies();
+    this.pkg?.addDevDependency('ts-node', '^10.9.2');
+  }
+
+  override shouldRun(config: GeneratorConfig): boolean {
+    return config.projectType === 'cdk-app';
+  }
+}

--- a/src/generators/cdk/cdk-common.ts
+++ b/src/generators/cdk/cdk-common.ts
@@ -1,0 +1,26 @@
+import { PackageJsonGenerator } from '../package-json/package-json-generator.js';
+import { ToolGenerator } from '../tool-generator.js';
+
+export const AWS_CDK_VERSION = '^2.201.0';
+export const CONSTRUCTS_VERSION = '^10.4.2';
+
+export abstract class CdkCommon extends ToolGenerator {
+  constructor(projectRoot: string, protected readonly pkg?: PackageJsonGenerator) {
+    super(projectRoot);
+  }
+
+  protected addDevDependencies(): void {
+    this.pkg?.addDevDependency('aws-cdk-lib', AWS_CDK_VERSION);
+    this.pkg?.addDevDependency('constructs', CONSTRUCTS_VERSION);
+  }
+
+  protected addPeerDependencies(): void {
+    this.pkg?.addPeerDependency('aws-cdk-lib', AWS_CDK_VERSION);
+    this.pkg?.addPeerDependency('constructs', CONSTRUCTS_VERSION);
+  }
+
+  protected addRuntimeDependencies(): void {
+    this.pkg?.addDependency('aws-cdk-lib', AWS_CDK_VERSION);
+    this.pkg?.addDependency('constructs', CONSTRUCTS_VERSION);
+  }
+}

--- a/src/generators/cdk/cdk-lib-generator.ts
+++ b/src/generators/cdk/cdk-lib-generator.ts
@@ -1,0 +1,35 @@
+import { mkdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { pascalCase } from '../../utils/string.js';
+import { GeneratorConfig } from '../tool-generator.js';
+import { CdkCommon } from './cdk-common.js';
+
+export class CdkLibGenerator extends CdkCommon {
+  name = 'cdk-lib';
+
+  async generate(config: GeneratorConfig): Promise<void> {
+    const name = config.projectName || 'cdk-lib';
+    const pascal = pascalCase(name);
+
+    await mkdir(resolve(this.projectRoot, 'lib'), { recursive: true });
+    const libContent = `import { Construct } from 'constructs';
+
+export interface ${pascal}Props {}
+
+export class ${pascal} extends Construct {
+  constructor(scope: Construct, id: string, props: ${pascal}Props = {}) {
+    super(scope, id);
+  }
+}
+`;
+    await this.writeTextFile('lib/index.ts', libContent);
+
+    this.addDevDependencies();
+    this.addPeerDependencies();
+  }
+
+  override shouldRun(config: GeneratorConfig): boolean {
+    return config.projectType === 'cdk-lib';
+  }
+}

--- a/src/generators/tool-registry.ts
+++ b/src/generators/tool-registry.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { CdkAppGenerator } from './cdk/cdk-app-generator.js';
+import { CdkLibGenerator } from './cdk/cdk-lib-generator.js';
 import { EslintGenerator } from './eslint/eslint-generator';
 import { GitGenerator } from './git/git-generator';
 import { PackageJsonGenerator } from './package-json/package-json-generator';
@@ -7,6 +9,8 @@ import { PrettierGenerator } from './prettier/prettier-generator';
 import { TsConfigGenerator } from './tsconfig/tsconfig-generator';
 
 export const toolGenerators = [
+  CdkAppGenerator,
+  CdkLibGenerator,
   EslintGenerator,
   GitGenerator,
   PackageJsonGenerator,

--- a/src/projects/project-generator.ts
+++ b/src/projects/project-generator.ts
@@ -1,3 +1,5 @@
+import { CdkAppGenerator } from '../generators/cdk/cdk-app-generator.js';
+import { CdkLibGenerator } from '../generators/cdk/cdk-lib-generator.js';
 import { EslintGenerator } from '../generators/eslint/eslint-generator.js';
 import { GitGenerator } from '../generators/git/git-generator.js';
 import { PackageJsonGenerator } from '../generators/package-json/package-json-generator.js';
@@ -17,6 +19,12 @@ export class ProjectGenerator {
       new PrettierGenerator(this.projectRoot, pkg),
       new GitGenerator(this.projectRoot),
     ];
+
+    if (config.projectType === 'cdk-app') {
+      this.generators.push(new CdkAppGenerator(this.projectRoot, pkg));
+    } else if (config.projectType === 'cdk-lib') {
+      this.generators.push(new CdkLibGenerator(this.projectRoot, pkg));
+    }
   }
 
   async generateAll(): Promise<void> {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,5 @@
+export function pascalCase(input: string): string {
+  return input
+    .replaceAll(/(^|[^a-zA-Z0-9]+)([a-zA-Z0-9])/g, (_m, _p1, p2) => p2.toUpperCase())
+    .replaceAll(/[^a-zA-Z0-9]/g, '');
+}

--- a/test/generators/cdk-generator.test.ts
+++ b/test/generators/cdk-generator.test.ts
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { CdkAppGenerator } from '../../src/generators/cdk/cdk-app-generator.js';
+import { AWS_CDK_VERSION } from '../../src/generators/cdk/cdk-common.js';
+import { CdkLibGenerator } from '../../src/generators/cdk/cdk-lib-generator.js';
+import { PackageJsonGenerator } from '../../src/generators/package-json/package-json-generator.js';
+
+describe('CdkGenerator', () => {
+  it('creates app files and dependencies for cdk-app', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'dcore-cdkapp-'));
+    const pkg = new PackageJsonGenerator(dir);
+    const gen = new CdkAppGenerator(dir, pkg);
+
+    await gen.generate({ projectName: 'demo', projectType: 'cdk-app', tools: {} });
+    await pkg.generate({ projectName: 'demo', projectType: 'cdk-app', tools: {} });
+
+    const cdkCfg = JSON.parse(await fs.readFile(join(dir, 'cdk.json'), 'utf8'));
+    const pkgJson = JSON.parse(await fs.readFile(join(dir, 'package.json'), 'utf8'));
+
+    expect(cdkCfg.app).to.equal('npx ts-node --prefer-ts-exts bin/demo.ts');
+    expect(pkgJson.dependencies['aws-cdk-lib']).to.equal(AWS_CDK_VERSION);
+    expect(pkgJson.devDependencies['aws-cdk-lib']).to.equal(AWS_CDK_VERSION);
+    expect(await fs.stat(join(dir, 'bin/demo.ts')).then(() => true, () => false)).to.equal(true);
+  });
+
+  it('creates library files and peer dependencies for cdk-lib', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'dcore-cdklib-'));
+    const pkg = new PackageJsonGenerator(dir);
+    const gen = new CdkLibGenerator(dir, pkg);
+
+    await gen.generate({ projectName: 'demo', projectType: 'cdk-lib', tools: {} });
+    await pkg.generate({ projectName: 'demo', projectType: 'cdk-lib', tools: {} });
+
+    const pkgJson = JSON.parse(await fs.readFile(join(dir, 'package.json'), 'utf8'));
+
+    expect(pkgJson.peerDependencies['aws-cdk-lib']).to.equal(AWS_CDK_VERSION);
+    expect(pkgJson.devDependencies['aws-cdk-lib']).to.equal(AWS_CDK_VERSION);
+    expect(await fs.stat(join(dir, 'lib/index.ts')).then(() => true, () => false)).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
- split CDK functionality into `CdkAppGenerator` and `CdkLibGenerator`
- update registry and project generator to use the new generators
- adjust tests for the new classes
- clean up imports and fix lint errors

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68507aa324cc83218de33079b7a73398