### PR TITLE
Add English typedoc comments and tests

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,9 +3,16 @@ import { Command } from '@oclif/core';
 import { loadDcoreConfig } from '../config/load-config.js';
 import { ProjectGenerator } from '../projects/project-generator.js';
 
+/**
+ * Default command which regenerates all project files according to the
+ * configuration.
+ */
 export default class Dcore extends Command {
   static description = 'Regenerate project files based on .dcorerc config';
 
+  /**
+   * Execute the command.
+   */
   async run(): Promise<void> {
     this.log('🔍 Loading .dcorerc configuration...');
     const config = await loadDcoreConfig();

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,6 +6,10 @@ import { basename, resolve } from 'node:path';
 import { loadDcoreConfig } from '../config/load-config.js';
 import { ProjectGenerator } from '../projects/project-generator.js';
 
+/**
+ * Initialize a new project by creating a configuration file and generating
+ * default project files.
+ */
 export default class Init extends Command {
   static description = 'Create a new .dcorerc.ts and generate project files';
   static flags = {
@@ -22,6 +26,9 @@ export default class Init extends Command {
     }),
   };
 
+  /**
+   * Execute the command.
+   */
   async run(): Promise<void> {
     const { flags } = await this.parse(Init);
     const file = resolve(process.cwd(), '.dcorerc.ts');

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -5,6 +5,9 @@ import { z } from 'zod';
 
 import { buildToolSchema } from '../generators/tool-registry.js';
 
+/**
+ * Zod schema describing the structure of `.dcorerc` configuration files.
+ */
 export const dcoreConfigSchema = z.object({
   ci: z.enum(['github', 'gitlab']).optional(),
   dependencies: z
@@ -36,6 +39,12 @@ const CONFIG_FILES = [
   '.dcorets.cjs',
 ];
 
+/**
+ * Load the dcore configuration from the current working directory.
+ *
+ * @param cwd - Directory to search for configuration files
+ * @returns The parsed configuration
+ */
 export async function loadDcoreConfig(
   cwd = process.cwd()
 ): Promise<DcoreConfig> {

--- a/src/generators/cdk/cdk-app-generator.ts
+++ b/src/generators/cdk/cdk-app-generator.ts
@@ -5,9 +5,15 @@ import { pascalCase } from '../../utils/string.js';
 import { GeneratorConfig } from '../tool-generator.js';
 import { CdkCommon } from './cdk-common.js';
 
+/**
+ * Generates scaffolding for an AWS CDK application.
+ */
 export class CdkAppGenerator extends CdkCommon {
   name = 'cdk-app';
 
+  /**
+   * Create the CDK app structure and update dependencies.
+   */
   async generate(config: GeneratorConfig): Promise<void> {
     const name = config.projectName || 'cdk-app';
     const pascal = pascalCase(name);
@@ -44,6 +50,7 @@ export class ${pascal}Stack extends cdk.Stack {
     this.pkg?.addDevDependency('ts-node', '^10.9.2');
   }
 
+  /** Only runs when the project type is `cdk-app`. */
   override shouldRun(config: GeneratorConfig): boolean {
     return config.projectType === 'cdk-app';
   }

--- a/src/generators/cdk/cdk-common.ts
+++ b/src/generators/cdk/cdk-common.ts
@@ -4,21 +4,27 @@ import { ToolGenerator } from '../tool-generator.js';
 export const AWS_CDK_VERSION = '^2.201.0';
 export const CONSTRUCTS_VERSION = '^10.4.2';
 
+/**
+ * Shared helper logic for CDK generators.
+ */
 export abstract class CdkCommon extends ToolGenerator {
   constructor(projectRoot: string, protected readonly pkg?: PackageJsonGenerator) {
     super(projectRoot);
   }
 
+  /** Add CDK related devDependencies. */
   protected addDevDependencies(): void {
     this.pkg?.addDevDependency('aws-cdk-lib', AWS_CDK_VERSION);
     this.pkg?.addDevDependency('constructs', CONSTRUCTS_VERSION);
   }
 
+  /** Add CDK related peerDependencies. */
   protected addPeerDependencies(): void {
     this.pkg?.addPeerDependency('aws-cdk-lib', AWS_CDK_VERSION);
     this.pkg?.addPeerDependency('constructs', CONSTRUCTS_VERSION);
   }
 
+  /** Add CDK related runtime dependencies. */
   protected addRuntimeDependencies(): void {
     this.pkg?.addDependency('aws-cdk-lib', AWS_CDK_VERSION);
     this.pkg?.addDependency('constructs', CONSTRUCTS_VERSION);

--- a/src/generators/cdk/cdk-lib-generator.ts
+++ b/src/generators/cdk/cdk-lib-generator.ts
@@ -5,9 +5,15 @@ import { pascalCase } from '../../utils/string.js';
 import { GeneratorConfig } from '../tool-generator.js';
 import { CdkCommon } from './cdk-common.js';
 
+/**
+ * Generates scaffolding for an AWS CDK construct library.
+ */
 export class CdkLibGenerator extends CdkCommon {
   name = 'cdk-lib';
 
+  /**
+   * Create the construct library structure and update dependencies.
+   */
   async generate(config: GeneratorConfig): Promise<void> {
     const name = config.projectName || 'cdk-lib';
     const pascal = pascalCase(name);
@@ -29,6 +35,7 @@ export class ${pascal} extends Construct {
     this.addPeerDependencies();
   }
 
+  /** Only runs when the project type is `cdk-lib`. */
   override shouldRun(config: GeneratorConfig): boolean {
     return config.projectType === 'cdk-lib';
   }

--- a/src/generators/eslint/eslint-generator.ts
+++ b/src/generators/eslint/eslint-generator.ts
@@ -7,6 +7,10 @@ import {
   ToolGenerator,
 } from '../tool-generator.js';
 
+/**
+ * Generates ESLint configuration files in either flat or legacy mode and
+ * registers the dependency.
+ */
 export class EslintGenerator extends ToolGenerator {
   name = 'eslint';
 
@@ -17,6 +21,9 @@ export class EslintGenerator extends ToolGenerator {
     super(projectRoot);
   }
 
+  /**
+   * Optional user configuration schema for ESLint.
+   */
   static override get configSchema() {
     return z.union([
       z.boolean(),
@@ -27,6 +34,9 @@ export class EslintGenerator extends ToolGenerator {
     ]);
   }
 
+  /**
+   * Write ESLint configuration and update dependencies.
+   */
   async generate(config: GeneratorConfig): Promise<void> {
     const toolCfg = this.getToolConfig(config);
     const isObj = typeof toolCfg === 'object' && toolCfg !== null;
@@ -73,6 +83,9 @@ export default ${JSON.stringify(merged, null, 2)};`;
     this.pkg?.addDevDependency('eslint', '^8.56.0');
   }
 
+  /**
+   * Default ESLint configuration used for the legacy `.eslintrc` format.
+   */
   protected override getDefaultConfig(): Record<string, unknown> {
     return {
       env: {
@@ -89,6 +102,9 @@ export default ${JSON.stringify(merged, null, 2)};`;
     };
   }
 
+  /**
+   * Run only when ESLint is enabled in the config.
+   */
   override shouldRun(config: GeneratorConfig): boolean {
     return Boolean(this.getToolConfig(config));
   }

--- a/src/generators/git/git-generator.ts
+++ b/src/generators/git/git-generator.ts
@@ -4,9 +4,15 @@ import { simpleGit } from 'simple-git';
 
 import { DEFAULT_IGNORE_ENTRIES, GeneratorConfig, ToolGenerator } from '../tool-generator.js';
 
+/**
+ * Handles creation of a `.gitignore` and repository initialization.
+ */
 export class GitGenerator extends ToolGenerator {
   name = 'git';
 
+  /**
+   * Generate git related files and optionally initialize a repository.
+   */
   async generate(config: GeneratorConfig): Promise<void> {
     const entries = [
       ...DEFAULT_IGNORE_ENTRIES,
@@ -28,6 +34,9 @@ export class GitGenerator extends ToolGenerator {
     }
   }
 
+  /**
+   * The git generator always runs.
+   */
   shouldRun(): boolean {
     return true;
   }

--- a/src/generators/package-json/get-fields.ts
+++ b/src/generators/package-json/get-fields.ts
@@ -1,5 +1,8 @@
 import type { GeneratorConfig } from '../tool-generator.js';
 
+/**
+ * Basic `package.json` fields derived from the global configuration.
+ */
 export function getBaseFields(config: Partial<GeneratorConfig>): Record<string, unknown> {
   return {
     author: config.projectAuthor || '',
@@ -12,6 +15,9 @@ export function getBaseFields(config: Partial<GeneratorConfig>): Record<string, 
   };
 }
 
+/**
+ * Build the scripts section for `package.json`.
+ */
 export function getScripts(config: Partial<GeneratorConfig>): Record<string, string> {
   const scripts: Record<string, string> = {
     build: 'tsc',
@@ -34,6 +40,9 @@ export function getScripts(config: Partial<GeneratorConfig>): Record<string, str
   return scripts;
 }
 
+/**
+ * Determine export related fields for `package.json`.
+ */
 export function getExportFields(config: Partial<GeneratorConfig>): Record<string, unknown> {
   const { exports: exp, files, main, types } = config.exports || {};
 
@@ -73,6 +82,9 @@ export function getExportFields(config: Partial<GeneratorConfig>): Record<string
   return {};
 }
 
+/**
+ * Convert a `Map` to a plain object.
+ */
 export function toObject(map: Map<string, string>): Record<string, string> {
   return Object.fromEntries(map.entries());
 }

--- a/src/generators/package-json/package-json-generator.ts
+++ b/src/generators/package-json/package-json-generator.ts
@@ -1,29 +1,40 @@
 import { GeneratorConfig, ToolGenerator } from '../tool-generator.js';
 import { getBaseFields, getExportFields, getScripts } from './get-fields.js';
 
+/**
+ * Writes the project's `package.json` file and collects dependencies from
+ * other generators.
+ */
 export class PackageJsonGenerator extends ToolGenerator {
   name = 'package.json';
-private dependencies = new Map<string, string>();
+  private dependencies = new Map<string, string>();
   private devDependencies = new Map<string, string>();
   private optionalDependencies = new Map<string, string>();
   private peerDependencies = new Map<string, string>();
 
+  /** Register a runtime dependency for the generated `package.json`. */
   addDependency(pkg: string, version: string): void {
     this.dependencies.set(pkg, version);
   }
 
+  /** Register a dev dependency for the generated `package.json`. */
   addDevDependency(pkg: string, version: string): void {
     this.devDependencies.set(pkg, version);
   }
 
+  /** Register an optional dependency for the generated `package.json`. */
   addOptionalDependency(pkg: string, version: string): void {
     this.optionalDependencies.set(pkg, version);
   }
 
+  /** Register a peer dependency for the generated `package.json`. */
   addPeerDependency(pkg: string, version: string): void {
     this.peerDependencies.set(pkg, version);
   }
 
+  /**
+   * Generate the `package.json` file based on collected information.
+   */
   async generate(config: GeneratorConfig): Promise<void> {
     const base = getBaseFields(config);
     const scripts = getScripts(config);
@@ -67,16 +78,21 @@ private dependencies = new Map<string, string>();
     await this.writeJsonFile('package.json', pkg);
   }
 
+  /** Default devDependencies that are always included. */
   protected getDefaultDevDeps(): Record<string, string> {
     return {
       typescript: '^5.3.3',
     };
   }
 
+  /** The package.json generator always runs. */
   shouldRun(): boolean {
     return true;
   }
 
+  /**
+   * Merge base dependencies with those collected by other generators.
+   */
   private mergeDeps(
     base: Record<string, string> = {},
     extras: Map<string, string>

--- a/src/generators/prettier/prettier-generator.ts
+++ b/src/generators/prettier/prettier-generator.ts
@@ -7,6 +7,10 @@ import {
   ToolGenerator,
 } from '../tool-generator.js';
 
+/**
+ * Generates Prettier configuration files and registers the dependency in
+ * package.json.
+ */
 export class PrettierGenerator extends ToolGenerator {
   name = 'prettier';
 
@@ -17,6 +21,9 @@ export class PrettierGenerator extends ToolGenerator {
     super(projectRoot);
   }
 
+  /**
+   * Optional user configuration schema for Prettier.
+   */
   static override get configSchema() {
     return z.union([
       z.boolean(),
@@ -33,6 +40,9 @@ export class PrettierGenerator extends ToolGenerator {
     ]);
   }
 
+  /**
+   * Write Prettier configuration and update dependencies.
+   */
   async generate(config: GeneratorConfig): Promise<void> {
     const raw = config.tools?.prettier;
     const prettierCfg = ToolGenerator.isRecord(raw)
@@ -45,6 +55,9 @@ export class PrettierGenerator extends ToolGenerator {
     this.pkg?.addDevDependency('prettier', '^3.2.5');
   }
 
+  /**
+   * Default Prettier settings used when the user does not provide their own.
+   */
   protected override getDefaultConfig(): Record<string, unknown> {
     return {
       arrowParens: 'always',
@@ -58,6 +71,9 @@ export class PrettierGenerator extends ToolGenerator {
     };
   }
 
+  /**
+   * Run only when the Prettier tool is enabled in the config.
+   */
   shouldRun(config: GeneratorConfig): boolean {
     return Boolean(config.tools?.prettier);
   }

--- a/src/generators/tool-generator.ts
+++ b/src/generators/tool-generator.ts
@@ -13,7 +13,7 @@ export const DEFAULT_IGNORE_ENTRIES = [
 ];
 
 /**
- * Die Konfigurationsstruktur für jeden Generator
+ * Configuration passed to each generator.
  */
 export interface GeneratorConfig extends DcoreConfig {
   exports?: {
@@ -30,7 +30,7 @@ export interface GeneratorConfig extends DcoreConfig {
 }
 
 /**
- * Abstrakte Basisklasse für Generatoren
+ * Base class for all generators.
  */
 export abstract class ToolGenerator {
   abstract name: string;
@@ -42,18 +42,18 @@ export abstract class ToolGenerator {
   }
 
   /**
-   * Optional: zod-Schema für Tool-spezifische Konfiguration
-   * (kann von Subklassen überschrieben werden)
+   * Optional Zod schema for tool specific configuration. Subclasses may
+   * override this method.
    */
   static get configSchema(): undefined | z.ZodTypeAny {
     return undefined;
   }
 
   /**
+   * Append entries to ignore files like `.gitignore` or `.npmignore`.
    *
-   * @param filename Name der Datei, die aktualisiert werden soll
-   * @description Fügt Einträge zu einer .gitignore- oder .npmignore-Datei hinzu
-   * @param entries Die Pfade oder Pattern, die ignoriert werden sollen
+   * @param filename - File that should be updated
+   * @param entries - Paths or patterns that should be ignored
    */
   protected async appendToIgnoreFile(
     filename: string,
@@ -79,19 +79,19 @@ export abstract class ToolGenerator {
   }
 
   /**
-   * Führt die Generierung aus
+   * Execute the generator.
    */
   abstract generate(config: GeneratorConfig): Promise<void>;
 
   /**
-   * Optional: Default-Konfiguration für Tool
+   * Optional default configuration for the tool.
    */
   protected getDefaultConfig(): Record<string, unknown> {
     return {};
   }
 
   /**
-   * Nutzt die Default-Konfiguration, gemerged mit der User-Konfiguration
+   * Merge the default configuration with the user provided configuration.
    */
   protected getMergedConfig(
     userConfig: boolean | Record<string, unknown>
@@ -111,12 +111,12 @@ export abstract class ToolGenerator {
   }
 
   /**
-   * Soll der Generator ausgeführt werden?
+   * Determine whether the generator should run.
    */
   abstract shouldRun(config: GeneratorConfig): boolean;
 
   /**
-   * Hilfsmethode zum Schreiben von JSON-Dateien
+   * Helper to write JSON files with a trailing newline.
    */
   protected async writeJsonFile(
     filename: string,
@@ -127,7 +127,7 @@ export abstract class ToolGenerator {
   }
 
   /**
-   * Hilfsmethode zum Schreiben von Text-Dateien
+   * Helper to write plain text files.
    */
   protected async writeTextFile(
     filename: string,

--- a/src/generators/tool-registry.ts
+++ b/src/generators/tool-registry.ts
@@ -8,6 +8,9 @@ import { PackageJsonGenerator } from './package-json/package-json-generator';
 import { PrettierGenerator } from './prettier/prettier-generator';
 import { TsConfigGenerator } from './tsconfig/tsconfig-generator';
 
+/**
+ * List of all available tool generators.
+ */
 export const toolGenerators = [
   CdkAppGenerator,
   CdkLibGenerator,
@@ -18,6 +21,9 @@ export const toolGenerators = [
   TsConfigGenerator,
 ];
 
+/**
+ * Build a Zod schema describing the configuration for all available tools.
+ */
 export function buildToolSchema(): z.AnyZodObject {
   const entries = toolGenerators
     .filter((g) => Boolean(g.configSchema))

--- a/src/generators/tsconfig/tsconfig-generator.ts
+++ b/src/generators/tsconfig/tsconfig-generator.ts
@@ -7,6 +7,9 @@ import {
   ToolGenerator,
 } from '../tool-generator.js';
 
+/**
+ * Generates a `tsconfig.json` and registers the TypeScript dependency.
+ */
 export class TsConfigGenerator extends ToolGenerator {
   name = 'tsconfig';
 
@@ -17,6 +20,9 @@ export class TsConfigGenerator extends ToolGenerator {
     super(projectRoot);
   }
 
+  /**
+   * Optional schema for user supplied tsconfig options.
+   */
   static override get configSchema() {
     return z
       .union([
@@ -32,6 +38,9 @@ export class TsConfigGenerator extends ToolGenerator {
       .optional();
   }
 
+  /**
+   * Generate the tsconfig file and register dependencies.
+   */
   async generate(config: Partial<GeneratorConfig> = {}): Promise<void> {
     const rawCfg = this.getToolConfig(config);
     const userCfg = ToolGenerator.isRecord(rawCfg) ? rawCfg : {};
@@ -40,6 +49,9 @@ export class TsConfigGenerator extends ToolGenerator {
     this.pkg?.addDevDependency('typescript', '^5.3.3');
   }
 
+  /**
+   * Default TypeScript configuration used as a base.
+   */
   protected override getDefaultConfig() {
     return {
       $schema: 'https://json.schemastore.org/tsconfig',
@@ -62,10 +74,16 @@ export class TsConfigGenerator extends ToolGenerator {
     };
   }
 
+  /**
+   * The tsconfig generator always runs.
+   */
   shouldRun(): boolean {
     return true;
   }
 
+  /**
+   * Merge default options with user supplied values.
+   */
   private mergeConfig(userCfg: Record<string, unknown>): Record<string, unknown> {
     const base = this.getDefaultConfig();
     const userOptions =

--- a/src/projects/project-generator.ts
+++ b/src/projects/project-generator.ts
@@ -7,9 +7,18 @@ import { PrettierGenerator } from '../generators/prettier/prettier-generator.js'
 import { GeneratorConfig, ToolGenerator } from '../generators/tool-generator.js';
 import { TsConfigGenerator } from '../generators/tsconfig/tsconfig-generator.js';
 
+/**
+ * Orchestrates all configured tool generators for a project.
+ */
 export class ProjectGenerator {
   private readonly generators: ToolGenerator[];
 
+  /**
+   * Create a new project generator.
+   *
+   * @param config - The generator configuration
+   * @param projectRoot - Location of the project, defaults to the current working directory
+   */
   constructor(private config: GeneratorConfig, private projectRoot = process.cwd()) {
     const pkg = new PackageJsonGenerator(this.projectRoot);
     this.generators = [
@@ -27,6 +36,9 @@ export class ProjectGenerator {
     }
   }
 
+  /**
+   * Run all configured generators in sequence.
+   */
   async generateAll(): Promise<void> {
     for (const generator of this.generators) {
       if (generator.shouldRun(this.config)) {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,3 +1,12 @@
+/**
+ * Convert a string to PascalCase.
+ *
+ * Every non alphanumeric character starts a new word and will be removed in the
+ * final result.
+ *
+ * @param input - The string to transform
+ * @returns The PascalCase version of the input
+ */
 export function pascalCase(input: string): string {
   return input
     .replaceAll(/(^|[^a-zA-Z0-9]+)([a-zA-Z0-9])/g, (_m, _p1, p2) => p2.toUpperCase())

--- a/test/utils/string.test.ts
+++ b/test/utils/string.test.ts
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+
+import { pascalCase } from '../../src/utils/string.js';
+
+describe('pascalCase', () => {
+  it('converts strings with separators to PascalCase', () => {
+    expect(pascalCase('hello-world')).to.equal('HelloWorld');
+    expect(pascalCase('foo_bar baz')).to.equal('FooBarBaz');
+  });
+
+  it('leaves alphanumeric strings intact', () => {
+    expect(pascalCase('Sample')).to.equal('Sample');
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive typedoc comments in English across sources
- include a new `pascalCase` utility test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850826b8614832181c9aa3016f43616