### PR TITLE
Fix git push step in release workflow

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -37,19 +37,24 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Setup git
         if: ${{ steps.version-check.outputs.skipped == 'false' }}
+        env:
+          GH_EMAIL: ${{ secrets.GH_EMAIL }}
+          GH_USERNAME: ${{ secrets.GH_USERNAME }}
         run: |
-          git config --global user.email ${{ secrets.GH_EMAIL }}
-          git config --global user.name ${{ secrets.GH_USERNAME }}
+          git config --global user.email "${GH_EMAIL:-${GITHUB_ACTOR}@users.noreply.github.com}"
+          git config --global user.name "${GH_USERNAME:-${GITHUB_ACTOR}}"
       - name: Generate oclif README
         if: ${{ steps.version-check.outputs.skipped == 'false' }}
         id: oclif-readme
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           pnpm install
           pnpm exec oclif readme
           if [ -n "$(git status --porcelain)" ]; then
             git add .
             git commit -am "chore: update README.md"
-            git push -u origin ${{ github.ref_name }}
+            git push -u "https://$GH_TOKEN@github.com/${{ github.repository }}" "${{ github.ref_name }}"
           fi
       - name: Create Github Release
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5


### PR DESCRIPTION
## Summary
- push README update using `GH_TOKEN` since `github-actions` user may not have permission

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_685097d5391083218c08ed4a69e19ead