### PR TITLE
Fix README push on release workflow

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,15 +48,13 @@ jobs:
       - name: Generate oclif README
         if: ${{ steps.version-check.outputs.skipped == 'false' }}
         id: oclif-readme
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           pnpm install
           pnpm exec oclif readme
           if [ -n "$(git status --porcelain)" ]; then
             git add .
             git commit -am "chore: update README.md"
-            git push -u "https://$GH_TOKEN@github.com/${{ github.repository }}" "${{ github.ref_name }}"
+            git push -u origin "${{ github.ref_name }}"
           fi
       - name: Create Github Release
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5


### PR DESCRIPTION
## Summary
- allow the release workflow to push to the repository
- simplify README push to rely on checkout credentials

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68509b2a99688321aab8faf05d05bb5f