### PR TITLE
Use builtin token for release workflow

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -35,8 +35,7 @@ jobs:
             echo "skipped=false" >> $GITHUB_OUTPUT
             echo "tag=v$package_version" >> $GITHUB_OUTPUT
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        # gh will automatically use the GITHUB_TOKEN provided by the workflow
       - name: Setup git
         if: ${{ steps.version-check.outputs.skipped == 'false' }}
         env:
@@ -63,5 +62,4 @@ jobs:
           name: ${{ steps.version-check.outputs.tag }}
           tag: ${{ steps.version-check.outputs.tag }}
           commit: ${{ github.ref_name }}
-          token: ${{ secrets.GH_TOKEN }}
           skipIfReleaseExists: true


### PR DESCRIPTION
## Summary
- fix GitHub release workflow by relying on the builtin `${{ github.token }}` via job permissions

## Testing
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_68509d87daa48321ab79388ec8530f5e