### PR TITLE
Add CLI init test to workflow

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -2,11 +2,15 @@
 name: version, tag and github release
 
 on:
-  push:
+  workflow_run:
+    workflows: ["tests"]
     branches: [main]
+    types:
+      - completed
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
       actions: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,24 @@ jobs:
       - run: pnpm install
       - run: pnpm run build
       - run: pnpm run test
+
+  cli-init:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+          run_install: false
+      - run: pnpm install
+      - run: pnpm run build
+      - name: run dmpak init
+        run: |
+          mkdir test-project
+          cd test-project
+          node ../bin/run.js init -f -t ts-lib
+          test -f .dmpakrc.ts

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -73,10 +73,11 @@ export async function loadDmpakConfig(
 
         // eslint-disable-next-line no-await-in-loop
         const { tsImport } = await import('tsx/esm/api');
-        // tsx handles absolute paths correctly on all platforms, so using the
-        // resolved path avoids issues with duplicated extensions on Windows.
+        // Node <18.19 requires file:// URLs on Windows; using the resolved path
+        // on other platforms avoids duplicated extensions.
+        const specifier = process.platform === 'win32' ? fileUrl : path;
         // eslint-disable-next-line no-await-in-loop
-        const imported = await tsImport(path, import.meta.url);
+        const imported = await tsImport(specifier, import.meta.url);
         rawConfig = imported.default?.default ?? imported.default ?? imported;
       } else {
         // eslint-disable-next-line no-await-in-loop

--- a/src/config/load-config.ts
+++ b/src/config/load-config.ts
@@ -73,10 +73,10 @@ export async function loadDmpakConfig(
 
         // eslint-disable-next-line no-await-in-loop
         const { tsImport } = await import('tsx/esm/api');
-        const specifier =
-          process.platform === 'win32' ? fileUrl : path;
+        // tsx handles absolute paths correctly on all platforms, so using the
+        // resolved path avoids issues with duplicated extensions on Windows.
         // eslint-disable-next-line no-await-in-loop
-        const imported = await tsImport(specifier, import.meta.url);
+        const imported = await tsImport(path, import.meta.url);
         rawConfig = imported.default?.default ?? imported.default ?? imported;
       } else {
         // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
## Summary
- test that `dmpak init` works inside CI
- only run release when tests pass

## Testing
- `pnpm install`
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6855104c458c8321bebd944a42b2fefc